### PR TITLE
Potential fix for code scanning alert no. 1: Unused import

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -15,7 +15,6 @@ import asyncio
 from src.tools import TOOL_REGISTRY
 from src.tools.refactor import refactor
 from src.tools.learn import learn
-from src.tools import nmap, nikto, dirsearch, sqlmap, waybackurls, nuclei
 from src.tools.pullpush import pullpush as pullpush_command
 
 


### PR DESCRIPTION
Potential fix for [https://github.com/akadevbarki76-collab/scaling-parakeet/security/code-scanning/1](https://github.com/akadevbarki76-collab/scaling-parakeet/security/code-scanning/1)

To fix the problem, we should remove the unused import statement on line 18: `from src.tools import nmap, nikto, dirsearch, sqlmap, waybackurls, nuclei`. This will eliminate the unnecessary dependency and improve code readability. No other changes are required, as none of these modules are referenced elsewhere in the provided code snippet. The edit should be made in `src/main.py`, specifically removing line 18.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
