### PR TITLE
Potential fix for code scanning alert no. 4: Unused import

### DIFF
--- a/tests/test_ai.py
+++ b/tests/test_ai.py
@@ -7,7 +7,6 @@ from unittest.mock import patch
 
 from click.testing import CliRunner
 from src.main import analyze
-from unittest.mock import patch, MagicMock
 
 
 


### PR DESCRIPTION
Potential fix for [https://github.com/akadevbarki76-collab/scaling-parakeet/security/code-scanning/4](https://github.com/akadevbarki76-collab/scaling-parakeet/security/code-scanning/4)

To fix the problem, we should remove the unused import of `MagicMock` from line 10. Since `patch` is already imported on line 6, the entire import statement on line 10 is redundant and can be deleted. No other changes are necessary, as this does not affect any existing functionality.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
